### PR TITLE
CleanHtml no longer adds extra brackets back into the result

### DIFF
--- a/RichTextEditor.Android/Converter.cs
+++ b/RichTextEditor.Android/Converter.cs
@@ -31,6 +31,7 @@ namespace RichTextEditor
 				{
 					inTag = true;
 					newString += c;
+                    continue;
 				}
 				else if (inTag)
 				{
@@ -41,13 +42,15 @@ namespace RichTextEditor
 							pTag = true;
 						}
 						newString += c;
-					}
+                        continue;
+                    }
 					if (c == '>')
 					{
 						inTag = false;
 						pTag = false;
 						newString += c;
-					}
+                        continue;
+                    }
 				}
 				else
 				{


### PR DESCRIPTION
added continue keyword at the end of most newstring addition commands to avoid running the rest of the loop